### PR TITLE
Implement versioning of jupyter-datascience images

### DIFF
--- a/charts/jupyter/Chart.yaml
+++ b/charts/jupyter/Chart.yaml
@@ -34,5 +34,5 @@ appVersion: latest
 
 dependencies:
   - name: library-chart
-    version: 1.1.3
+    version: 1.1.4
     repository: https://inseefrlab.github.io/helm-charts-datascience

--- a/charts/jupyter/values.schema.json
+++ b/charts/jupyter/values.schema.json
@@ -24,7 +24,10 @@
                       "version": {
                         "description": "jupyter supported version",
                         "type": "string",
-                        "enum": ["inseefrlab/jupyter-datascience:master"],
+                        "enum": [
+                            "inseefrlab/jupyter-datascience:py3.9.7-spark3.1.2",
+                            "inseefrlab/jupyter-datascience:py3.7.6-spark3.1.1"
+                                ],
                         "pattern": "^[a-z0-9-_./]+(:[a-z0-9-_.]+)?$",
                         "hidden": {
                             "value": true,

--- a/charts/jupyter/values.yaml
+++ b/charts/jupyter/values.yaml
@@ -4,12 +4,12 @@ service:
   user: jovyan
   sparkui: false
   image:
-    version: "inseefrlab/jupyter-datascience:master"
+    version: "inseefrlab/jupyter-datascience:py3.9.7-spark3.1.2"
     pullPolicy: IfNotPresent
     custom:
       enabled: false
-      version: "inseefrlab/jupyter-datascience:master"
-  
+      version: "inseefrlab/jupyter-datascience:py3.9.7-spark3.1.2"
+
 security:
   password: "changeme"
   networkPolicy: 


### PR DESCRIPTION
- Allow users to select their version of the jupyter-datascience image when starting a jupyter service
- Provide a new image with everything upgraded (python 3.9.7 - spark 3.1.2 - hadoop 3.3.1 - hive 2.3.7 - jupyterlab 3.2.0)