### PR TITLE
Changer le tag utilitR suite à la mise à jour de la documentation

### DIFF
--- a/charts/rstudio/Chart.yaml
+++ b/charts/rstudio/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 5.2.2
+version: 5.3.0
 
 dependencies:
   - name: library-chart

--- a/charts/rstudio/values.schema.json
+++ b/charts/rstudio/values.schema.json
@@ -21,7 +21,7 @@
                         "type": "string",
                         "enum": [
                             "inseefrlab/rstudio:4.1.1", "inseefrlab/rstudio:4.0.4", 
-                            "inseefrlab/rstudio:3.6.3", "inseefrlab/utilitr:0.7.0"
+                            "inseefrlab/rstudio:3.6.3", "inseefrlab/utilitr:0.8.0"
                         ],
                         "pattern": "^[a-z0-9-_./]+(:[a-z0-9-_.]+)?$",
                         "hidden": {


### PR DESCRIPTION
`utilitr:0.8.0` est la dernière version taguée