### PR TITLE
"fixuid -q" removed from vscode launch command

### DIFF
--- a/charts/vscode/templates/deployment.yaml
+++ b/charts/vscode/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
           image: "{{ .Values.service.image.version }}"
           {{- end }} 
           command: ["/bin/sh","-c"]
-          args: ["/data/{{ .Values.init.filename}} fixuid -q /usr/bin/code-server --host 0.0.0.0 /home/coder/work"]
+          args: ["/data/{{ .Values.init.filename}} /usr/bin/code-server --host 0.0.0.0 /home/coder/work"]
           imagePullPolicy: {{ .Values.service.image.pullPolicy }}
           env:
             - name: SHELL


### PR DESCRIPTION
We had a CrashLoopBackOff at the Vscode pod launch. The removal of the fixuid fixed the issue.