### PR TITLE
trino jmx exporter, update 378 default version

### DIFF
--- a/charts/trino/Chart.yaml
+++ b/charts/trino/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 3.0.3
+version: 3.1.0
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/trino/templates/configmap-coordinator.yaml
+++ b/charts/trino/templates/configmap-coordinator.yaml
@@ -29,6 +29,9 @@ data:
     -XX:PerMethodRecompilationCutoff=10000
     -XX:PerBytecodeRecompilationCutoff=10000
     -Djdk.nio.maxCachedBufferSize=2000000
+  {{- if .Values.metrics.jmx.enabled }}
+    -Dcom.sun.management.jmxremote.rmi.port=9081
+  {{- end }}
   {{- range $configValue := .Values.additionalJVMConfig }}
     {{ $configValue }}
   {{- end }}
@@ -44,7 +47,8 @@ data:
     query.max-memory={{ .Values.server.config.query.maxMemory }}
     query.max-memory-per-node={{ .Values.server.config.query.maxMemoryPerNode }}
     memory.heap-headroom-per-node={{ .Values.server.config.memory.heapHeadroomPerNode }}
-    discovery-server.enabled=true
+    #deprecated
+    #discovery-server.enabled=true
     discovery.uri=http://localhost:{{ .Values.networking.port }}
     http-server.authentication.type=PASSWORD
     http-server.process-forwarded=true
@@ -53,6 +57,10 @@ data:
   {{- end }}
   {{- if .Values.coordinator.enabled }}
   {{ .Values.coordinator.extraConfigs | indent 4 }}
+  {{- end }}
+  {{- if .Values.metrics.jmx.enabled }}
+    jmx.rmiregistry.port=9080
+    jmx.rmiserver.port=9081
   {{- end }}
   password-authenticator.properties: |
     password-authenticator.name=file

--- a/charts/trino/templates/configmap-jmx.yaml
+++ b/charts/trino/templates/configmap-jmx.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.metrics.jmx.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "library-chart.fullname" . }}-jmx
+  labels:
+    {{- include "library-chart.labels" . | nindent 4 }}
+data:
+  jmx-trino-prometheus.yml: |
+    jmxUrl: service:jmx:rmi:///jndi/rmi://127.0.0.1:9080/jmxrmi
+    lowercaseOutputName: true
+    lowercaseOutputLabelNames: true
+    ssl: false
+{{- end -}}

--- a/charts/trino/templates/configmap-worker.yaml
+++ b/charts/trino/templates/configmap-worker.yaml
@@ -29,6 +29,9 @@ data:
     -XX:PerMethodRecompilationCutoff=10000
     -XX:PerBytecodeRecompilationCutoff=10000
     -Djdk.nio.maxCachedBufferSize=2000000
+  {{- if .Values.metrics.jmx.enabled }}
+    -Dcom.sun.management.jmxremote.rmi.port=9081
+  {{- end }}
   {{- range $configValue := .Values.additionalJVMConfig }}
     {{ $configValue }}
   {{- end }}
@@ -40,6 +43,10 @@ data:
     query.max-memory-per-node={{ .Values.server.config.query.maxMemoryPerNode }}
     memory.heap-headroom-per-node={{ .Values.server.config.memory.heapHeadroomPerNode }}
     discovery.uri=http://{{ include "library-chart.fullname" . }}:{{ .Values.networking.port }}
+  {{- if .Values.metrics.jmx.enabled }}
+    jmx.rmiregistry.port=9080
+    jmx.rmiserver.port=9081
+  {{- end }}
   {{- range $configValue := .Values.additionalConfigProperties }}
     {{ $configValue }}
   {{- end }}

--- a/charts/trino/templates/deployment-coordinator.yaml
+++ b/charts/trino/templates/deployment-coordinator.yaml
@@ -31,6 +31,11 @@ spec:
         - name: hdfs-config
           configMap: 
             name: {{ include "library-chart.configMapNameCoreSite" . }}
+      {{- if .Values.metrics.jmx.enabled }}
+        - name: jmx-config
+          configMap:
+            name: {{ include "library-chart.fullname" . }}-jmx
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -68,6 +73,33 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+        {{- if .Values.metrics.jmx.enabled }}
+        - name: {{ .Chart.Name }}-jmx-exporter
+          image: "{{ .Values.metrics.jmx.image.version }}"
+          imagePullPolicy: {{ .Values.metrics.jmx.image.pullPolicy | quote }}
+          {{- if .Values.metrics.jmx.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.metrics.jmx.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          command:
+            - java
+            - -XX:+UnlockExperimentalVMOptions
+            - -XX:+UseCGroupMemoryLimitForHeap
+            - -XX:MaxRAMFraction=1
+            - -XshowSettings:vm
+            - -jar
+            - jmx_prometheus_httpserver.jar
+            - {{ .Values.metrics.jmx.containerPorts.metrics | quote }}
+            - /etc/jmx/jmx-trino-prometheus.yml
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.metrics.jmx.containerPorts.metrics }}
+          {{- if .Values.metrics.jmx.resources }}
+          resources: {{- toYaml .Values.metrics.jmx.resources | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: jmx-config
+              mountPath: /etc/jmx
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/trino/templates/deployment-worker.yaml
+++ b/charts/trino/templates/deployment-worker.yaml
@@ -28,6 +28,11 @@ spec:
         - name: hdfs-config
           configMap:
             name: {{ include "library-chart.configMapNameCoreSite" . }}
+        {{- if .Values.metrics.jmx.enabled }}
+        - name: jmx-config
+          configMap:
+            name: {{ include "library-chart.fullname" . }}-jmx
+        {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -64,7 +69,34 @@ spec:
               path: /v1/info
               port: http
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}         
+            {{- toYaml .Values.resources | nindent 12 }}
+        {{- if .Values.metrics.jmx.enabled }}
+        - name: {{ .Chart.Name }}-jmx-exporter
+          image: "{{ .Values.metrics.jmx.image.version }}"
+          imagePullPolicy: {{ .Values.metrics.jmx.image.pullPolicy | quote }}
+          {{- if .Values.metrics.jmx.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.metrics.jmx.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          command:
+            - java
+            - -XX:+UnlockExperimentalVMOptions
+            - -XX:+UseCGroupMemoryLimitForHeap
+            - -XX:MaxRAMFraction=1
+            - -XshowSettings:vm
+            - -jar
+            - jmx_prometheus_httpserver.jar
+            - {{ .Values.metrics.jmx.containerPorts.metrics | quote }}
+            - /etc/jmx/jmx-trino-prometheus.yml
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.metrics.jmx.containerPorts.metrics }}
+          {{- if .Values.metrics.jmx.resources }}
+          resources: {{- toYaml .Values.metrics.jmx.resources | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: jmx-config
+              mountPath: /etc/jmx
+        {{- end }}       
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/trino/values.schema.json
+++ b/charts/trino/values.schema.json
@@ -20,14 +20,16 @@
 							"description": "supported versions",
 							"type": "string",
 							"enum": [
-								"inseefrlab/trino:374"
+								"inseefrlab/trino:374",
+								"inseefrlab/trino:376",
+								"inseefrlab/trino:378"
 							],
 							"pattern": "^[a-z0-9-_./]+(:[a-z0-9-_.]+)?$",
 							"hidden": {
 								"value": true,
 								"path": "service/image/custom/enabled"
 							},
-							"default": "inseefrlab/trino:374"
+							"default": "inseefrlab/trino:378"
 						},
 						"custom": {
 							"description": "use a custom trino image",
@@ -42,7 +44,7 @@
 								"version": {
 									"description": "trino unsupported version",
 									"type": "string",
-									"default": "inseefrlab/trino:374",
+									"default": "inseefrlab/trino:378",
 									"pattern": "^[a-z0-9-_./]+(:[a-z0-9-_.]+)?$",
 									"hidden": {
 										"value": false,

--- a/charts/trino/values.yaml
+++ b/charts/trino/values.yaml
@@ -105,6 +105,20 @@ additionalCatalogs: []
 # Array of EnvVar (https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#envvar-v1-core)
 env: []
 
+metrics:
+  jmx:
+    enabled: false
+    image:
+      version: "bitnami/jmx-exporter:0.16.1-debian-10-r281"
+      pullPolicy: IfNotPresent
+    containerPorts:
+      metrics: 5555
+    containerSecurityContext:
+      enabled: true
+      runAsUser: 1000
+      runAsGroup: 1000
+      runAsNonRoot: true
+
 securityContext:
   runAsUser: 1000
   runAsGroup: 1000
@@ -137,7 +151,7 @@ ingress:
   annotations:
     kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  hostname: alexis-trino.kub.sspcloud.fr
+  hostname: chart-example.local
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local


### PR DESCRIPTION
**jmx sidecar**
Trino could only be monitor with jmx.
I've made like bitnami charts (sonarqube, kafka) using sidecar jmx-exporter-prometheus to publish jmx prometheus on an endpoint ready for prometheus.
It shoud be safe as jmx.enabled control this behavior.
To use it in grafana in datalab i need some help.

**default to 378 version and add older in enum**
Let's try 378 as last version

