### PR TITLE
Bump argocd

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -24,17 +24,16 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.6
+version: 2.0.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1
+appVersion: "1"
 dependencies:
   - name: argo-cd
-    version: 3.33.5
+    version: 4.5.7
     repository: https://argoproj.github.io/argo-helm
-    enabled: true
   - name: library-chart
     version: 2.0.20
     repository: https://inseefrlab.github.io/helm-charts-datascience

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -17,9 +17,9 @@ ingress:
   #      - chart-example.local
 
 security:
-    allowlist:
-      enabled: true
-      ip: "0.0.0.0/0"
+  allowlist:
+    enabled: true
+    ip: "0.0.0.0/0"
 
 global:
   networkPolicy:
@@ -27,6 +27,10 @@ global:
     defaultDenyIngress: false
 
 argo-cd:
+  notifications:
+    enabled: false
+  applicationSet:
+    enabled: false
   createAggregateRoles: false
   fullnameOverride: "argocd"
   controller:
@@ -44,14 +48,14 @@ argo-cd:
       selfHealTimeout: "5"
       repoServerTimeoutSeconds: "60"
     extraArgs:
-    - --namespace
-    - $(KUBERNETES_NAMESPACE)
+      - --namespace
+      - $(KUBERNETES_NAMESPACE)
     env:
-    - name: KUBERNETES_NAMESPACE
-      valueFrom:
-       fieldRef:
-         apiVersion: v1
-         fieldPath: metadata.namespace
+      - name: KUBERNETES_NAMESPACE
+        valueFrom:
+          fieldRef:
+            apiVersion: v1
+            fieldPath: metadata.namespace
     logFormat: text
     logLevel: info
     containerPort: 8082
@@ -79,14 +83,14 @@ argo-cd:
     name: server
     replicas: 1
     extraArgs:
-    - --namespace
-    - $(KUBERNETES_NAMESPACE)
+      - --namespace
+      - $(KUBERNETES_NAMESPACE)
     env:
-    - name: KUBERNETES_NAMESPACE
-      valueFrom:
-       fieldRef:
-         apiVersion: v1
-         fieldPath: metadata.namespace
+      - name: KUBERNETES_NAMESPACE
+        valueFrom:
+          fieldRef:
+            apiVersion: v1
+            fieldPath: metadata.namespace
     logFormat: text
     logLevel: info
     containerPort: 8080
@@ -97,7 +101,7 @@ argo-cd:
     ingress:
       enabled: false
     clusterAdminAccess:
-      enabled: false      
+      enabled: false
 
   repoServer:
     name: repo-server
@@ -118,6 +122,7 @@ argo-cd:
 
 secret:
   createSecret: true
-  password: changeme
-      # Password modification time defaults to current time if not set
-      # argocdServerAdminPasswordMtime: "2006-01-02T15:04:05Z"
+  password:
+    changeme
+    # Password modification time defaults to current time if not set
+    # argocdServerAdminPasswordMtime: "2006-01-02T15:04:05Z"


### PR DESCRIPTION
Bump argocd to app version 2.3.  
Disabling the new `notifications` and `applicationSet` modules for now