### PR TITLE
add listener jar path env var

### DIFF
--- a/charts/hive-metastore/templates/deployment.yaml
+++ b/charts/hive-metastore/templates/deployment.yaml
@@ -45,6 +45,8 @@ spec:
               value: {{ .Values.listener.kafka-topic-name }}
             - name: DOMAIN_NAMESPACE
               value: {{ .Values.listener.domain-namespace }}
+            - name: HIVE_AUX_JARS_PATH
+              value: {{ .Values.listener.jar-path }}
           {{ end }} 
           readinessProbe:
             tcpSocket:

--- a/charts/hive-metastore/values.yaml
+++ b/charts/hive-metastore/values.yaml
@@ -53,6 +53,7 @@ listener:
   kafka-broker-url: kafka-0.kafka-headless:9092
   kafka-topic-name: hive-meta
   domain-namespace: user-pengfei
+  jar-path: "/opt/hive/lib/hive-listener.jar"
 
 readiness:
   enabled: "true"


### PR DESCRIPTION
I belived that if I put the listener jar file in /lib, the hive metastore will load the jar into its classpath automatically. But it does not work on my test local. So I added the env var recommended by hive for the listener jar. And test passed   